### PR TITLE
Fix: Generar índice durante build del Docker para evitar error 503

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,14 @@ WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Copiar datos PRIMERO
+COPY data/ ./data/
+
 # Copiar el resto de la aplicación
 COPY . .
+
+# Generar el índice ANTES de iniciar
+RUN python prepare_data.py
 
 # Exponer el puerto en el que correrá la aplicación
 EXPOSE 8000


### PR DESCRIPTION
Se agrega generación automática del índice en storage/ durante el build - Copiar datos antes de generar el índice - Solucionar fallo de inicialización del chatbot en GCP